### PR TITLE
Adding image pruning at startup to prevent disk saturation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ COPY --from=builder /usr/src/etcher/node_modules/electron/ /usr/src/app/node_mod
 WORKDIR /usr/src/app/node_modules/.bin
 RUN ln -s ../electron/cli.js electron
 
-RUN apt-get update && apt-get install exfat-fuse lzma
+RUN apt-get update && apt-get install exfat-fuse lzma docker.io
 
 COPY zram.sh /usr/src/app/
 COPY screensaver_on.sh screensaver_off.sh /usr/bin/
@@ -67,6 +67,7 @@ WORKDIR /usr/src/app
 COPY start_cd.elf ./generated/modules/node-raspberrypi-usbboot/blobs/raspberrypi/start_cd.elf
 
 CMD \
-	./zram.sh \
+  docker image prune -a -f \
+	&& ./zram.sh \
 	&& node /usr/src/app/update-config-and-start.js
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
     labels:
       io.balena.features.dbus: 1
       io.balena.features.supervisor-api: 1
+      io.balena.features.balena-socket: 1
     volumes:
       - 'etcher_cache:/root/.cache'
       - 'etcher_config:/root/.config/balena-etcher'


### PR DESCRIPTION
Adding `docker image prune -a -f` before starting `etcher` to remove old images left by the OS.
This should prevent /mnt/data to fill up on products with updates.

Change-type: patch