### PR TITLE
Fixing screensaver restart delay

### DIFF
--- a/screensaver_off.sh
+++ b/screensaver_off.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
+dbus-send --system --dest=org.freedesktop.systemd1 --type=method_call --print-reply /org/freedesktop/systemd1 org.freedesktop.systemd1.Manager.StartUnit string:gov-switch.service string:replace
+
 if [ ! -d /sys/class/gpio/gpio101 ]; then echo 101 > /sys/class/gpio/export; fi
 if [ -d /sys/class/gpio/gpio101 ]; then echo 1 > /sys/class/gpio/gpio101/value; fi
 if [ ! -d /sys/class/gpio/gpio131 ]; then echo 131 > /sys/class/gpio/export; fi
 if [ -d /sys/class/gpio/gpio131 ]; then echo 0 > /sys/class/gpio/gpio131/value; fi
+sleep 0.3
 if [ -d /sys/class/pwm/pwmchip2/pwm0 ]; then echo 1 > /sys/class/pwm/pwmchip2/pwm0/enable; fi
-dbus-send --system --dest=org.freedesktop.systemd1 --type=method_call --print-reply /org/freedesktop/systemd1 org.freedesktop.systemd1.Manager.StartUnit string:gov-switch.service string:replace


### PR DESCRIPTION
Changing `screensaver_off.sh` sequence and adding 300ms delay to let some time for the display to settle before enabling backlight.

Change-type: patch
Signed-off-by: Aurélien VALADE <aurelien.valade@balena.io>