### PR TITLE
Reverting Etcher build to COPY etcher folder instead of Git clonning it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,9 @@ COPY tsconfig.json update-config-and-start.ts ./
 RUN npm i && npx tsc update-config-and-start.ts
 
 WORKDIR /usr/src/
+COPY etcher etcher
 COPY build-etcher.sh ./build-etcher.sh
 #Ensure we clear the balena builder cache to fetch latest etcher
-ADD "https://api.github.com/repos/balena-io/etcher/commits?per_page=1" etcher_latest_commit
 RUN chmod +x ./build-etcher.sh && ./build-etcher.sh
 
 # runtime image

--- a/build-etcher.sh
+++ b/build-etcher.sh
@@ -1,5 +1,4 @@
 gem install fpm --no-document
-git clone --recurse-submodules --depth 1 https://github.com/balena-io/etcher
 cd etcher
 export NODE_OPTIONS="--max-old-space-size=1024"
 export PUPPETEER_SKIP_DOWNLOAD=1


### PR DESCRIPTION
This has been done to improve etcher's traceability and avoid unwanted side-effects.

Change-type: patch