### PR TITLE
Adding BALENAELECTRONJS_REMOTE_INSPECT_PORT to enable node inspection…

### DIFF
--- a/.xinitrc
+++ b/.xinitrc
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+if [ -n "$XRANDR_ARGS" ]; then
+	xrandr $XRANDR_ARGS
+fi
+
+REMOTE_DEBUG=""
+if [ -n "$BALENAELECTRONJS_REMOTE_DEBUGGING_PORT" ]; then
+	LOCAL_PORT=`expr $BALENAELECTRONJS_REMOTE_DEBUGGING_PORT - 1`
+	REMOTE_DEBUG="--remote-debugging-port=$LOCAL_PORT"
+	# --remote-debugging-port only listens on 127.0.0.1 so we set up a proxy listening on all interfaces
+	simpleproxy -d -L $BALENAELECTRONJS_REMOTE_DEBUGGING_PORT -R 127.0.0.1:$LOCAL_PORT
+fi
+
+REMOTE_INSPECT=""
+if [ -n "$BALENAELECTRONJS_REMOTE_INSPECT_PORT" ]; then
+	LOCAL_PORT=`expr $BALENAELECTRONJS_REMOTE_INSPECT_PORT - 1`
+	REMOTE_INSPECT="--inspect=$LOCAL_PORT"
+	# --remote-debugging-port only listens on 127.0.0.1 so we set up a proxy listening on all interfaces
+	simpleproxy -d -L $BALENAELECTRONJS_REMOTE_INSPECT_PORT -R 127.0.0.1:$LOCAL_PORT
+fi
+
+metacity &
+dbus-daemon --fork --session --address $DBUS_SESSION_BUS_ADDRESS
+/usr/src/app/node_modules/.bin/electron $REMOTE_DEBUG $REMOTE_INSPECT --no-sandbox -r /usr/lib/balena-electron-env /usr/src/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN chmod +x /usr/bin/screensaver_off.sh
 RUN chmod +x /usr/bin/screensaver_on.sh
 
 COPY --from=builder /usr/src/app/update-config-and-start.js /usr/src/app
+COPY .xinitrc /root/.xinitrc
 
 WORKDIR /usr/src/app
 # correct .elf is part of etcher-sdk since 7.4.2


### PR DESCRIPTION
… on electron

Enabling node inspection on electron is necessary to use playwright remote connection to electon. This will be used for integration testing.

Change-type: patch